### PR TITLE
Include typescript definitions for generated components

### DIFF
--- a/package/tsconfig.components.json
+++ b/package/tsconfig.components.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig",
+  "include": [
+    "v3/**/*.vue"
+  ],
+  "compilerOptions": {
+    "emitDeclarationOnly": true,
+    "outDir": "."
+  }
+}

--- a/package/tsconfig.components.json
+++ b/package/tsconfig.components.json
@@ -5,6 +5,6 @@
   ],
   "compilerOptions": {
     "emitDeclarationOnly": true,
-    "outDir": "."
+    "outDir": ""
   }
 }

--- a/src/generator/custom.elements.ts
+++ b/src/generator/custom.elements.ts
@@ -23,7 +23,7 @@ import {
   isImportsProviderDecorator,
   isMethodsDecorator
 } from './decorators/types.ts'
-import { camel2kebab, getNthGroupMatch } from './utils.ts'
+import { camel2kebab } from './utils.ts'
 
 /**
  * Some Vivid custom elements classes breaks the naming convention, this map is needed to mitigate that fact
@@ -94,7 +94,7 @@ const getComponentsDefinitions = async () => {
   const vComponentsIndexResponse = await fetch(`${libFolderUrl}/components.d.ts`)
   const componentsIndex = await vComponentsIndexResponse.text()
   const componentDefinitionsUrls = componentsIndex.split('\n')
-    .map((exportStatement: string) => getNthGroupMatch(/'\.(.*)'/g, exportStatement))
+    .map((exportStatement: string) => exportStatement.match(/'\.(.*)'/)?.[1])
     .filter(x => x)
     .map(x => `${libFolderUrl}${x}.d.ts`)
 

--- a/src/generator/custom.elements.ts
+++ b/src/generator/custom.elements.ts
@@ -100,7 +100,7 @@ const getComponentsDefinitions = async () => {
 
   const componentDefinitions = []
   console.info(`Downloading elements definitions`)
-  for await (const componentDefinitionUrl of componentDefinitionsUrls) {
+  for (const componentDefinitionUrl of componentDefinitionsUrls) {
     const response = await fetch(componentDefinitionUrl)
     const componentDefinitionText = await response.text()
     componentDefinitions.push(componentDefinitionText)
@@ -178,7 +178,7 @@ export const enumerateVividElements = async (
     typeDeclarations: {}
   }
 
-  for await (const classDeclaration of classDeclarations) {
+  for (const classDeclaration of classDeclarations) {
     const imports = []
     let properties = classDeclaration.members as ClassField[] || []
     let methods = classDeclaration.members as ClassMethod[] || []

--- a/src/generator/decorators/anchortype.decorator.ts
+++ b/src/generator/decorators/anchortype.decorator.ts
@@ -28,8 +28,8 @@ export class AnchorTypeDecorator extends AbstractClassDeclarationDecorator imple
   }
 
   replaceAnchorType = (property: PropertyLike) => {
-    if (property.type?.text.toLowerCase() === 'anchortype') {
-      property.type.text = 'string | HTMLElement'
+    if (property.type?.text) {
+      property.type.text = property.type.text.replace(/\b[Aa]nchorType\b/g, 'string | HTMLElement')
     }
   }
 }

--- a/src/generator/decorators/anchortype.decorator.ts
+++ b/src/generator/decorators/anchortype.decorator.ts
@@ -1,0 +1,35 @@
+import { ClassField, ClassMethod, PropertyLike } from 'https://esm.sh/custom-elements-manifest@latest/schema.d.ts'
+import {
+  AbstractClassDeclarationDecorator,
+  IMethodsDecorator,
+  IPropertiesDecorator,
+} from "./types.ts"
+
+/**
+ * Inlines type defintions for properties and method arguments of type `anchorType` or `AnchorType`,
+ * as those type aliases are not exported by vivid.
+ */
+export class AnchorTypeDecorator extends AbstractClassDeclarationDecorator implements
+  IMethodsDecorator,
+  IPropertiesDecorator {
+
+  decorateProperties = (properties: ClassField[]) => {
+    for (const p of properties) {
+      this.replaceAnchorType(p)
+    }
+    return properties
+  }
+
+  decorateMethods(methods: ClassMethod[]): ClassMethod[] {
+    for (const p of methods.flatMap(m => m.parameters ?? [])) {
+      this.replaceAnchorType(p)
+    }
+    return methods
+  }
+
+  replaceAnchorType = (property: PropertyLike) => {
+    if (property.type?.text.toLowerCase() === 'anchortype') {
+      property.type.text = 'string | HTMLElement'
+    }
+  }
+}

--- a/src/generator/decorators/imports.decorator.ts
+++ b/src/generator/decorators/imports.decorator.ts
@@ -16,29 +16,15 @@ export class ImportsDecorator extends AbstractClassDeclarationDecorator implemen
   IMethodsDecorator,
   IImportsProviderDecorator {
 
-  extraImports: Record<string, string[]> = {
-    AccordionItem: [
-      "import { AccordionItemSize } from '@vonage/vivid/lib/accordion-item/accordion-item'"
-    ],
-    Alert: [
-      "import { AlertPlacement } from '@vonage/vivid/lib/alert/alert'"
-    ],
-    Checkbox: [
-      "import { CheckboxConnotation } from '@vonage/vivid/lib/checkbox/checkbox'"
-    ],
-    DataGrid: [
-      "import { DataGridSelectionMode } from '@vonage/vivid/lib/data-grid/data-grid'"
-    ],
-    Pagination: [
-      "import { PaginationSize } from '@vonage/vivid/lib/pagination/pagination'",
-      "import { Button } from '@vonage/vivid/lib/button/button'"
-    ],
-    Radio: [
-      "import { RadioConnotation } from '@vonage/vivid/lib/radio/radio'"
-    ],
-    Tabs: [
-      "import { TabsConnotation } from '@vonage/vivid/lib/tabs/tabs'"
-    ]
+  extraImports: Record<string, string> = {
+    AccordionItemSize: '@vonage/vivid/lib/accordion-item/accordion-item',
+    AlertPlacement: '@vonage/vivid/lib/alert/alert',
+    CheckboxConnotation: '@vonage/vivid/lib/checkbox/checkbox',
+    DataGridSelectionMode: '@vonage/vivid/lib/data-grid/data-grid',
+    PaginationSize: '@vonage/vivid/lib/pagination/pagination',
+    Button: '@vonage/vivid/lib/button/button',
+    RadioConnotation: '@vonage/vivid/lib/radio/radio',
+    TabsConnotation: '@vonage/vivid/lib/tabs/tabs',
   }
 
   protected methods: ClassMethod[] = []
@@ -56,11 +42,15 @@ export class ImportsDecorator extends AbstractClassDeclarationDecorator implemen
     ]
   }
 
+  get vividInternallyExportedTypes(): string[] {
+    return this.referencedTypeNames.filter(x => x in this.extraImports && !this.isVividExportedType(x))
+  }
+
   get imports(): string[] {
     return [
       `import { ${this.vividExportedTypes.join(', ')} } from '@vonage/vivid'`,
       ...(this.methods.length > 0 ? [`import { ref } from 'vue'`] : []),
-      ...(this.extraImports[this.className] ?? [])
+      ...(this.vividInternallyExportedTypes.map(x => `import { ${x} } from '${this.extraImports[x]}'`))
     ]
   }
 

--- a/src/generator/mod.ts
+++ b/src/generator/mod.ts
@@ -101,7 +101,7 @@ export const generate = async () => {
       .map(([name, { specifier, assignment, declaration, description }]) => `/**\n*  ${description}\n*/\nexport ${[specifier, name, assignment].filter(Boolean).join(' ')} ${declaration.text}`).join('\n'))
   )
 
-  for await (const stylesFile of [
+  for (const stylesFile of [
     { name: 'core.all', url: 'https://unpkg.com/@vonage/vivid@latest/styles/core/all.css' },
     { name: 'theme.light', url: 'https://unpkg.com/@vonage/vivid@latest/styles/tokens/theme-light.css' },
     { name: 'theme.dark', url: 'https://unpkg.com/@vonage/vivid@latest/styles/tokens/theme-dark.css' }

--- a/src/generator/mod.ts
+++ b/src/generator/mod.ts
@@ -14,6 +14,7 @@ import { SlotsDecorator } from './decorators/slots.decorator.ts'
 import { StylePropertyDecorator } from './decorators/style.property.decorator.ts'
 import { renderVividVueComponent } from './render.vue.component.ts'
 import { fillPlaceholders } from './utils.ts'
+import { AnchorTypeDecorator } from './decorators/anchortype.decorator.ts'
 
 /**
  * Enumerates all valid Vivid custom elements and generates the output to the `./package` folder
@@ -59,6 +60,7 @@ export const generate = async () => {
       CssPropertiesDecorator,
       SlotsDecorator,
       PropertiesDecorator,
+      AnchorTypeDecorator,
       EventsDecorator,
       IconTypeDecorator,
       StylePropertyDecorator,

--- a/src/generator/templates/root.package.json.template
+++ b/src/generator/templates/root.package.json.template
@@ -11,7 +11,7 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "build": "vite build"
+    "build": "vite build && npx vue-tsc -p tsconfig.components.json"
   },
   "dependencies": {
     "@vonage/vivid": "<%= vividPackageVersion %>",
@@ -24,6 +24,7 @@
     "typescript": "4.9.4",
     "vite": "4.1.4",
     "vitest": "0.28.5",
-    "vite-plugin-dts": "1.7.1"
+    "vite-plugin-dts": "1.7.1",
+    "vue-tsc": "^1.8.6"
   }
 }

--- a/src/generator/templates/root.package.json.template
+++ b/src/generator/templates/root.package.json.template
@@ -11,7 +11,7 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "build": "vite build && npx vue-tsc -p tsconfig.components.json"
+    "build": "vite build && vue-tsc -p tsconfig.components.json"
   },
   "dependencies": {
     "@vonage/vivid": "<%= vividPackageVersion %>",

--- a/src/generator/utils.ts
+++ b/src/generator/utils.ts
@@ -2,23 +2,6 @@ const deCapitalize = (input: string) => input.replace(/(^|\s)[A-Z]/g, s => s.toL
 export const camel2kebab = (input: string) => deCapitalize(input).replace(/([a-z])([A-Z])/g, "$1-$2").replace(/[\s_]+/g, '-').toLowerCase()
 export const kebab2camel = (input: string) => input.replace(/-([A-Za-z0-9])/g, (_, p1) => p1.toUpperCase())
 export const toValidIdentifier = (input: string) => input.replace(/^\d+/, '')
-export const getNthGroupMatch = (
-  regExp: RegExp,
-  content: string,
-  nth = 1
-): string => {
-  let index = 0
-  let result = content
-  let regexResult
-  do {
-    regexResult = regExp.exec(content)
-    if (regexResult) {
-      result = regexResult[nth]
-    }
-    index++
-  } while (regexResult)
-  return result
-}
 const readTemplate = async (
   name = ''
 ): Promise<string | undefined> => {


### PR DESCRIPTION
Fixes #1 

The types in `extraImports` are currently not exported from the vivid root, but are exported from specific files inside vivid, so we import them from there. If they are exported from the root in future, then the generate will import them from the root instead (which is why `vividInternallyExportedTypes` checks `isVividExportedType`).

I didn't really understand the point of `getNthGroupMatch`, it looked like it was largely equivalent to the builtin regex `match()` method - so I removed it and replaced the single usage with `match()`. If there is a good reason to keep `getNthGroupMatch` then I'm happy to revert that commit