### PR TITLE
Export components props interface to allow extending

### DIFF
--- a/src/generator/mod.ts
+++ b/src/generator/mod.ts
@@ -89,7 +89,7 @@ export const generate = async () => {
       await Deno.writeFile(
         `${componentPackageDir}/${vueComponentName}.vue`,
         new TextEncoder().encode(await renderVividVueComponent(`${templatesFolder}/vue.component.template`, {
-          properties, methods, events, slots, imports, tagName, tagPrefix, classDeclaration, vividElementDocUrl, vueModel
+          properties, methods, events, slots, imports, tagName, tagPrefix, classDeclaration, vividElementDocUrl, vueModel, vueComponentName
         }))
       )
     }

--- a/src/generator/render.vue.component.ts
+++ b/src/generator/render.vue.component.ts
@@ -41,10 +41,11 @@ const renderTagProps = (methods: ClassMethod[], properties: ClassField[], events
 
 const renderProps = (
   properties: ClassField[],
-  vueModel?: VueModel
+  vueModel?: VueModel,
+  vueComponentName?: string,
 ): string =>
   properties.length > 0
-    ? `defineProps<{\n${properties.concat(vueModel ? [{
+    ? `export interface ${vueComponentName}Props {\n${properties.concat(vueModel ? [{
       name: 'modelValue',
       description: 'v-model property',
       kind: 'field',
@@ -57,7 +58,7 @@ const renderProps = (
           `  ${x.description ? `/**\n  * ${x.description}\n  */\n  ` : ''
           }${x.name}?: ${x.type ? x.type.text : 'any'}`
       )
-      .join('\n')}\n}>()`
+      .join('\n')}\n}\ndefineProps<${vueComponentName}Props>()`
     : ''
 
 const renderEvents = (
@@ -88,7 +89,7 @@ const renderEvents = (
  * @returns code content for .vue SFC file https://vuejs.org/api/sfc-spec.html#sfc-syntax-specification
  */
 export const renderVividVueComponent = async (template: string,
-  { classDeclaration, tagPrefix, tagName, properties, methods, events, slots, imports, vividElementDocUrl, vueModel }:
+  { classDeclaration, tagPrefix, tagName, properties, methods, events, slots, imports, vividElementDocUrl, vueModel, vueComponentName }:
     Partial<IVividElementVisitorContext> & IVividElementsContext
 ) => await fillPlaceholders(template)({
   componentRegisterMethod: getElementRegistrationFunctionName(classDeclaration!),
@@ -99,6 +100,6 @@ export const renderVividVueComponent = async (template: string,
   tagPrefix,
   methods: renderMethods(methods!),
   events: renderEvents(events!, vueModel),
-  props: renderProps(properties!, vueModel),
+  props: renderProps(properties!, vueModel, vueComponentName),
   tagProps: renderTagProps(methods!, properties!, events!, vueModel),
 })


### PR DESCRIPTION
Small adjustment to generator code, to output components properties as separate exported interface:
![image](https://github.com/Vonage/vivid-bindings-vue/assets/135825473/e7601a29-fe2e-4f3d-b1ea-5efd0eba6740)

This should allow to create components that pass through properties via interface extending, like this:
![image](https://github.com/Vonage/vivid-bindings-vue/assets/135825473/08f6f2d7-4c9e-4730-982a-1f06a5ff5a8f)

In this example we pass through all default VwcCard properties, while extending base interface with "footer" property. With that, we can use this component without redefining all basic VwcCard properties:
![image](https://github.com/Vonage/vivid-bindings-vue/assets/135825473/8e8b98ed-bacf-4853-8009-1ea2ca0c7c23)
