### PR TITLE
Respect members/events inherited from superclass

### DIFF
--- a/src/generator/custom.elements.inheritance.ts
+++ b/src/generator/custom.elements.inheritance.ts
@@ -1,0 +1,192 @@
+import fastFoundationCustomElements from "https://esm.sh/@microsoft/fast-foundation@2/dist/custom-elements.json" assert {
+  type: "json",
+};
+import {
+  ClassLike,
+  Package,
+  Reference,
+  CustomElementDeclaration,
+} from "https://esm.sh/custom-elements-manifest@latest/schema.d.ts";
+import { getClassDeclarations } from "./utils.ts";
+
+type Declaration = CustomElementDeclaration & ClassLike;
+
+const fastFoundationClasses = getClassDeclarations(fastFoundationCustomElements as Package) as Declaration[]
+
+/**
+ * Base declaration for all elements.
+ * All custom elements extend HTMLElement and thereby inherit all a variety of events and attributes.
+ * However, we declare only a meaningful subset of these here.
+ */
+const BaseElementDeclaration: Declaration = {
+  name: 'HTMLElement',
+  kind: 'class',
+  members: [
+    {
+      kind: "field",
+      name: 'aria-current',
+      description:
+        'Indicates the element that represents the current item within a container or set of related elements.',
+      type: { text: "'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'" },
+    },
+  ],
+  events: [
+    {
+      name: 'click',
+      description: `Fires when a pointing device button (such as a mouse's primary mouse button) is both pressed and released while the pointer is located inside the element.`,
+      type: { text: 'MouseEvent' },
+    },
+    {
+      name: 'focus',
+      description: 'Fires when the element receives focus.',
+      type: { text: 'FocusEvent' },
+    },
+    {
+      name: 'blur',
+      description: 'Fires when the element loses focus.',
+      type: { text: 'FocusEvent' },
+    },
+    {
+      name: 'keydown',
+      description: 'Fires when a key is pressed.',
+      type: { text: 'KeyboardEvent' },
+    },
+    {
+      name: 'keyup',
+      description: 'Fires when a key is released.',
+      type: { text: 'KeyboardEvent' },
+    },
+    {
+      name: 'input',
+      description: 'Fires when the value of an element has been changed.',
+      type: { text: 'Event' },
+    },
+  ],
+  customElement: true,
+};
+
+/**
+ * Form associated classes like FormAssociatedButton are not exported in the manifest.
+ * Instead, we need to provide the declaration here, based on the code:
+ * https://github.com/microsoft/fast/blob/master/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
+ */
+const getFastFormAssociatedDeclaration = (className: string): CustomElementDeclaration  => {
+  const declaration: Declaration = {
+    name: className,
+    kind: "class",
+    members: [
+      {
+        kind: "field",
+        name: "disabled",
+        description:
+          "Sets the element's disabled state. A disabled element will not be included during form submission.",
+        type: { text: "boolean" },
+      },
+      {
+        kind: "field",
+        name: "value",
+        description:
+          `The initial value of the form. This value sets the \`value\` property
+only when the \`value\` property has not been explicitly set.`,
+        type: { text: "string" },
+      },
+      {
+        kind: "field",
+        name: "current-value",
+        description:
+          `The current value of the element. This property serves as a mechanism
+to set the \`value\` property through both property assignment and the
+.setAttribute() method. This is useful for setting the field's value
+in UI libraries that bind data through the .setAttribute() API
+and don't support IDL attribute binding.`,
+        type: { text: "string" },
+      },
+      {
+        kind: "field",
+        name: "name",
+        description:
+          `The name of the element. This element's value will be surfaced during form submission under the provided name.`,
+        type: { text: "string" },
+      },
+      {
+        kind: "field",
+        name: "required",
+        description:
+          `Require the field to be completed prior to form submission.`,
+        type: { text: "boolean" },
+      },
+    ],
+    superclass: {
+      name: "FoundationElement",
+    },
+    customElement: true,
+  };
+
+  // Only checkbox and radio differ from the base class
+  if (
+    className === "FormAssociatedCheckbox" ||
+    className === "FormAssociatedRadio"
+  ) {
+    declaration.members!.push(
+      {
+        kind: "field",
+        name: "checked",
+        description: `Provides the default checkedness of the input element`,
+        type: { text: "boolean" },
+      },
+      {
+        kind: "field",
+        name: "current-checked",
+        description:
+          `The current checkedness of the element. This property serves as a mechanism
+to set the \`checked\` property through both property assignment and the
+.setAttribute() method. This is useful for setting the field's checkedness
+in UI libraries that bind data through the .setAttribute() API
+and don't support IDL attribute binding.`,
+        type: { text: "boolean" },
+      },
+    );
+  }
+
+  return declaration;
+};
+
+// Inherit items that are not already present in the child
+function inheritItems<T>(getName: (item: T) => string, superItems: T[] = [], childItems: T[] = []): T[] {
+  return [...superItems.filter(s => !childItems.some(c => getName(s) === getName(c))), ...childItems];
+}
+
+const resolveComponentDeclaration = (reference: Reference): Declaration | undefined => {
+  let declaration: Declaration | undefined
+
+  if (reference.name.startsWith('FormAssociated')) {
+    // Form associated classes (FormAssociatedButton etc.) are not exported in the manifest
+    declaration = getFastFormAssociatedDeclaration(reference.name);
+  } else if (reference.name === 'FoundationElement') {
+    // This is the base class for all elements
+    declaration = BaseElementDeclaration;
+  } else if (reference.package === '@microsoft/fast-foundation' && reference.name !== 'FoundationElement') {
+    // Remove prefixes added by Vivid
+    const fastClassName = reference.name.replace(/^(Foundation|Fast)/i, '');
+    declaration = fastFoundationClasses.find(c => c.name.toLowerCase() === fastClassName.toLowerCase())
+  }
+
+  if (declaration) {
+    addInheritedItems(declaration)
+  }
+
+  return declaration
+};
+
+export const addInheritedItems = (classLike: ClassLike) => {
+  const declaration = classLike as Declaration
+  const superclassDeclaration = declaration.superclass ? resolveComponentDeclaration(declaration.superclass) : undefined
+
+  if (superclassDeclaration) {
+    // Inherit members and events from the superclass
+    // Note: we don't inherit slots, as Vivid components often don't implement them
+    // we also don't inherit attributes, because they're duplicated as members
+    declaration.members = inheritItems(m => m.name, superclassDeclaration.members?.filter(m => m.inheritedFrom?.name !== 'FoundationElement'), declaration.members);
+    declaration.events = inheritItems(m => m.name, superclassDeclaration.events, declaration.events);
+  }
+}

--- a/src/generator/decorators/events.decorator.ts
+++ b/src/generator/decorators/events.decorator.ts
@@ -11,14 +11,6 @@ export class EventsDecorator extends AbstractClassDeclarationDecorator implement
   IEventsDecorator {
 
   extraEventsMap: Record<string, Event[]> = {
-    Button: [
-      {
-        name: 'click',
-        type: {
-          text: 'PointerEvent'
-        }
-      }
-    ],
     Banner: [
       {
         name: 'removing',

--- a/src/generator/utils.ts
+++ b/src/generator/utils.ts
@@ -1,12 +1,30 @@
+import {
+  Package,
+  Declaration,
+  ClassLike
+} from 'https://esm.sh/custom-elements-manifest@latest/schema.d.ts'
+
 const deCapitalize = (input: string) => input.replace(/(^|\s)[A-Z]/g, s => s.toLowerCase())
 export const camel2kebab = (input: string) => deCapitalize(input).replace(/([a-z])([A-Z])/g, "$1-$2").replace(/[\s_]+/g, '-').toLowerCase()
 export const kebab2camel = (input: string) => input.replace(/-([A-Za-z0-9])/g, (_, p1) => p1.toUpperCase())
 export const toValidIdentifier = (input: string) => input.replace(/^\d+/, '')
+
 const readTemplate = async (
   name = ''
 ): Promise<string | undefined> => {
   const decoder = new TextDecoder('utf-8')
   return decoder.decode(await Deno.readFile(name))
 }
+
 export const fillPlaceholders = (template?: string) => async (substitutions: Record<string, string>) =>
   Object.entries(substitutions).reduce((input, [key, value]) => (input || '').replaceAll(`<%= ${key} %>`, value), await readTemplate(template))
+
+export const getClassDeclarations = (customElements: Package): ClassLike[] =>
+  customElements.modules.reduce((acc, { declarations }) =>
+    [
+      ...acc,
+      ...(declarations || []).filter(({ kind }) => kind === 'class')
+    ]
+    ,
+    [] as Declaration[]
+  )


### PR DESCRIPTION
`VwcButton.vue` Before:
<details>

```vue
<!-- VWC stands for "Vivid Web Component" for more context visit https://vivid.deno.dev -->
<!-- Do not edit this file manually - this component has been auto-generated using `definition.json` model -->
<!-- For more info on this Vivid element please visit https://vivid.deno.dev/components/button -->
<template>
  <vvd3-button
    v-bind="$props"
    :style="style"
    :title="title"
    :connotation="connotation"
    :shape="shape"
    :appearance="appearance"
    :size="size"
    :stacked="stacked"
    :pending="pending"
    :label="label"
    :icon="icon"
    :iconTrailing="iconTrailing"
    @click="$emit('click', $event)"
  ></vvd3-button>
</template>

<script setup lang="ts">
import { IconId } from '../../src/generated/types'
import { CSSProperties } from 'vue'
import { registerButton, ButtonConnotation, ButtonShape, ButtonAppearance, ButtonSize } from '@vonage/vivid'
export interface VwcButtonProps {
  /**
  * Inline styles object includes standard CSSProperties plus custom css variables suitable for this Vivid element
  */
  style?: CSSProperties & {
    /**
    * undefined
    */
    '--vvd-button-cta-primary'?: any
    /**
    * undefined
    */
    '--vvd-button-cta-primary-text'?: any
    /**
    * undefined
    */
    '--vvd-button-cta-primary-increment'?: any
    /**
    * undefined
    */
    '--vvd-button-cta-contrast'?: any
    /**
    * undefined
    */
    '--vvd-button-cta-fierce'?: any
    /**
    * undefined
    */
    '--vvd-button-cta-firm'?: any
    /**
    * undefined
    */
    '--vvd-button-cta-soft'?: any
    /**
    * undefined
    */
    '--vvd-button-cta-faint'?: any
    /**
    * undefined
    */
    '--vvd-button-success-primary'?: any
    /**
    * undefined
    */
    '--vvd-button-success-primary-text'?: any
    /**
    * undefined
    */
    '--vvd-button-success-primary-increment'?: any
    /**
    * undefined
    */
    '--vvd-button-success-contrast'?: any
    /**
    * undefined
    */
    '--vvd-button-success-fierce'?: any
    /**
    * undefined
    */
    '--vvd-button-success-firm'?: any
    /**
    * undefined
    */
    '--vvd-button-success-soft'?: any
    /**
    * undefined
    */
    '--vvd-button-success-faint'?: any
    /**
    * undefined
    */
    '--vvd-button-alert-primary'?: any
    /**
    * undefined
    */
    '--vvd-button-alert-primary-text'?: any
    /**
    * undefined
    */
    '--vvd-button-alert-primary-increment'?: any
    /**
    * undefined
    */
    '--vvd-button-alert-contrast'?: any
    /**
    * undefined
    */
    '--vvd-button-alert-fierce'?: any
    /**
    * undefined
    */
    '--vvd-button-alert-firm'?: any
    /**
    * undefined
    */
    '--vvd-button-alert-soft'?: any
    /**
    * undefined
    */
    '--vvd-button-alert-faint'?: any
    /**
    * undefined
    */
    '--vvd-button-accent-primary'?: any
    /**
    * undefined
    */
    '--vvd-button-accent-primary-text'?: any
    /**
    * undefined
    */
    '--vvd-button-accent-primary-increment'?: any
    /**
    * undefined
    */
    '--vvd-button-accent-contrast'?: any
    /**
    * undefined
    */
    '--vvd-button-accent-fierce'?: any
    /**
    * undefined
    */
    '--vvd-button-accent-firm'?: any
    /**
    * undefined
    */
    '--vvd-button-accent-soft'?: any
    /**
    * undefined
    */
    '--vvd-button-accent-faint'?: any
  }
  title?: string
  /**
  * The connotation the button should have.
  */
  connotation?: ButtonConnotation | undefined
  /**
  * The shape the button should have.
  */
  shape?: ButtonShape | undefined
  /**
  * The appearance the button should have.
  */
  appearance?: ButtonAppearance | undefined
  /**
  * The size the button should have.
  */
  size?: ButtonSize | undefined
  /**
  * Indicates the icon is stacked.
  */
  stacked?: boolean
  /**
  * Displays the button in pending state.
  */
  pending?: boolean
  /**
  * Indicates the button's label.
  */
  label?: string | undefined
  /**
  * Icon id. One of 1149 icons. Catalog with preview/search can be found at https://icons.vivid.vonage.com
  */
  icon?: IconId
  /**
  * Indicates the icon affix alignment.
  */
  iconTrailing?: boolean
}
defineProps<VwcButtonProps>()
defineEmits<{
  (event: 'click', payload: PointerEvent): void
}>()
registerButton('vvd3')
</script>
```
</details>

And after:
<details>

```vue
<!-- VWC stands for "Vivid Web Component" for more context visit https://vivid.deno.dev -->
<!-- Do not edit this file manually - this component has been auto-generated using `definition.json` model -->
<!-- For more info on this Vivid element please visit https://vivid.deno.dev/components/button -->
<template>
  <vvd3-button
    v-bind="$props"
    ref="element"
    :style="style"
    :aria-current="aria-current"
    :disabled="disabled"
    :value="value"
    :current-value="current-value"
    :name="name"
    :required="required"
    :autofocus="autofocus"
    :formId="formId"
    :formaction="formaction"
    :formenctype="formenctype"
    :formmethod="formmethod"
    :formnovalidate="formnovalidate"
    :formtarget="formtarget"
    :type="type"
    :defaultSlottedContent="defaultSlottedContent"
    :control="control"
    :proxy="proxy"
    :title="title"
    :connotation="connotation"
    :shape="shape"
    :appearance="appearance"
    :size="size"
    :stacked="stacked"
    :pending="pending"
    :label="label"
    :icon="icon"
    :iconTrailing="iconTrailing"
    @click="$emit('click', $event)"
    @focus="$emit('focus', $event)"
    @blur="$emit('blur', $event)"
    @keydown="$emit('keydown', $event)"
    @keyup="$emit('keyup', $event)"
    @input="$emit('input', $event)"
  ></vvd3-button>
</template>

<script setup lang="ts">
import { IconId } from '../../src/generated/types'
import { CSSProperties } from 'vue'
import { registerButton, ButtonConnotation, ButtonShape, ButtonAppearance, ButtonSize } from '@vonage/vivid'
import { ref } from 'vue'
export interface VwcButtonProps {
  /**
  * Inline styles object includes standard CSSProperties plus custom css variables suitable for this Vivid element
  */
  style?: CSSProperties & {
    /**
    * undefined
    */
    '--vvd-button-cta-primary'?: any
    /**
    * undefined
    */
    '--vvd-button-cta-primary-text'?: any
    /**
    * undefined
    */
    '--vvd-button-cta-primary-increment'?: any
    /**
    * undefined
    */
    '--vvd-button-cta-contrast'?: any
    /**
    * undefined
    */
    '--vvd-button-cta-fierce'?: any
    /**
    * undefined
    */
    '--vvd-button-cta-firm'?: any
    /**
    * undefined
    */
    '--vvd-button-cta-soft'?: any
    /**
    * undefined
    */
    '--vvd-button-cta-faint'?: any
    /**
    * undefined
    */
    '--vvd-button-success-primary'?: any
    /**
    * undefined
    */
    '--vvd-button-success-primary-text'?: any
    /**
    * undefined
    */
    '--vvd-button-success-primary-increment'?: any
    /**
    * undefined
    */
    '--vvd-button-success-contrast'?: any
    /**
    * undefined
    */
    '--vvd-button-success-fierce'?: any
    /**
    * undefined
    */
    '--vvd-button-success-firm'?: any
    /**
    * undefined
    */
    '--vvd-button-success-soft'?: any
    /**
    * undefined
    */
    '--vvd-button-success-faint'?: any
    /**
    * undefined
    */
    '--vvd-button-alert-primary'?: any
    /**
    * undefined
    */
    '--vvd-button-alert-primary-text'?: any
    /**
    * undefined
    */
    '--vvd-button-alert-primary-increment'?: any
    /**
    * undefined
    */
    '--vvd-button-alert-contrast'?: any
    /**
    * undefined
    */
    '--vvd-button-alert-fierce'?: any
    /**
    * undefined
    */
    '--vvd-button-alert-firm'?: any
    /**
    * undefined
    */
    '--vvd-button-alert-soft'?: any
    /**
    * undefined
    */
    '--vvd-button-alert-faint'?: any
    /**
    * undefined
    */
    '--vvd-button-accent-primary'?: any
    /**
    * undefined
    */
    '--vvd-button-accent-primary-text'?: any
    /**
    * undefined
    */
    '--vvd-button-accent-primary-increment'?: any
    /**
    * undefined
    */
    '--vvd-button-accent-contrast'?: any
    /**
    * undefined
    */
    '--vvd-button-accent-fierce'?: any
    /**
    * undefined
    */
    '--vvd-button-accent-firm'?: any
    /**
    * undefined
    */
    '--vvd-button-accent-soft'?: any
    /**
    * undefined
    */
    '--vvd-button-accent-faint'?: any
  }
  /**
  * Indicates the element that represents the current item within a container or set of related elements.
  */
  aria-current?: 'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'
  /**
  * Sets the element's disabled state. A disabled element will not be included during form submission.
  */
  disabled?: boolean
  /**
  * The initial value of the form. This value sets the `value` property
only when the `value` property has not been explicitly set.
  */
  value?: string
  /**
  * The current value of the element. This property serves as a mechanism
to set the `value` property through both property assignment and the
.setAttribute() method. This is useful for setting the field's value
in UI libraries that bind data through the .setAttribute() API
and don't support IDL attribute binding.
  */
  current-value?: string
  /**
  * The name of the element. This element's value will be surfaced during form submission under the provided name.
  */
  name?: string
  /**
  * Require the field to be completed prior to form submission.
  */
  required?: boolean
  /**
  * Determines if the element should receive document focus on page load.
  */
  autofocus?: boolean
  /**
  * The id of a form to associate the element to.
  */
  formId?: string
  /**
  * See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button | <button> element} for more details.
  */
  formaction?: string
  /**
  * See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button | <button> element} for more details.
  */
  formenctype?: string
  /**
  * See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button | <button> element} for more details.
  */
  formmethod?: string
  /**
  * See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button | <button> element} for more details.
  */
  formnovalidate?: boolean
  /**
  * See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button | <button> element} for more details.
  */
  formtarget?: "_self" | "_blank" | "_parent" | "_top"
  /**
  * The button type.
  */
  type?: "submit" | "reset" | "button"
  /**
  * 
Default slotted content
  */
  defaultSlottedContent?: HTMLElement[]
  control?: HTMLButtonElement
  proxy?: any
  title?: string
  /**
  * The connotation the button should have.
  */
  connotation?: ButtonConnotation | undefined
  /**
  * The shape the button should have.
  */
  shape?: ButtonShape | undefined
  /**
  * The appearance the button should have.
  */
  appearance?: ButtonAppearance | undefined
  /**
  * The size the button should have.
  */
  size?: ButtonSize | undefined
  /**
  * Indicates the icon is stacked.
  */
  stacked?: boolean
  /**
  * Displays the button in pending state.
  */
  pending?: boolean
  /**
  * Indicates the button's label.
  */
  label?: string | undefined
  /**
  * Icon id. One of 1149 icons. Catalog with preview/search can be found at https://icons.vivid.vonage.com
  */
  icon?: IconId
  /**
  * Indicates the icon affix alignment.
  */
  iconTrailing?: boolean
}
defineProps<VwcButtonProps>()
defineEmits<{
  /**
  * Fires when a pointing device button (such as a mouse's primary mouse button) is both pressed and released while the pointer is located inside the element.
  */
  (event: 'click', payload: MouseEvent): void
  /**
  * Fires when the element receives focus.
  */
  (event: 'focus', payload: FocusEvent): void
  /**
  * Fires when the element loses focus.
  */
  (event: 'blur', payload: FocusEvent): void
  /**
  * Fires when a key is pressed.
  */
  (event: 'keydown', payload: KeyboardEvent): void
  /**
  * Fires when a key is released.
  */
  (event: 'keyup', payload: KeyboardEvent): void
  /**
  * Fires when the value of an element has been changed.
  */
  (event: 'input', payload: Event): void
}>()
const element = ref<HTMLElement | null>(null)
defineExpose({
  /**
  *  {@inheritDoc (FormAssociated:interface).validate}
  */
  validate: (): void => (element.value as any)?.validate()
})
registerButton('vvd3')
</script>
```
</details>

Still to do: fix kebab-case props, e.g. `aria-current`, as I think it's currently causing invalid typescript