### PR TITLE
Define `target`/`currentTarget` as `any` for generic events

### DIFF
--- a/src/generator/render.vue.component.ts
+++ b/src/generator/render.vue.component.ts
@@ -3,6 +3,8 @@ import { getElementRegistrationFunctionName, IVividElementsContext, IVividElemen
 import { AsyncClassMethod, InlineClassMethod } from './decorators/types.ts'
 import { fillPlaceholders, kebab2camel } from './utils.ts'
 
+const defaultEmitType = 'Event & { target: any, currentTarget: any }'
+
 const renderMethods = (methods: ClassMethod[]): string =>
   methods.length > 0 ? (
     `\nconst element = ref<HTMLElement | null>(null)\n` +
@@ -82,7 +84,7 @@ const renderEvents = (
       .map(
         (x) =>
           `  ${x.description ? `/**\n  * ${x.description}\n  */\n  ` : ''
-          }(event: '${x.name}', payload: ${x.type?.text ?? 'Event'}): void`
+          }(event: '${x.name}', payload: ${x.type?.text ?? defaultEmitType}): void`
       )
       .join('\n')}\n}>()`
     : ''


### PR DESCRIPTION
This allows consumers to do `@change="doStuff($event.target.value)"` etc.

The actual type of `target`/`currentTarget` depends on which element fires the event, and while the element type will be exported from vivid, finding the right path to the type is nontrivial, so this weaker type seems like a reasonable compromise