### PR TITLE
Inherit attributes from mixins

### DIFF
--- a/src/generator/decorators/attributes.decorator.ts
+++ b/src/generator/decorators/attributes.decorator.ts
@@ -39,82 +39,6 @@ export class AttributesDecorator extends AbstractClassDeclarationDecorator imple
     return this.slots.filter(({ name }) => name).map(({ name, description }) => `- \`${name}\` - ${description}`).join('\n')
   }
 
-  iconAttribute: Attribute = {
-    name: "icon",
-    description: 'Indicates which icon to resolve.',
-    type: {
-      text: "string"
-    }
-  }
-
-  /**
-   * TODO: To address issue to https://custom-elements-manifest.open-wc.org/
-   * issue: CEM Analyzer is not catching inherited properties & attributes
-   *
-   * Mitigation path: Vivid elements has to be documented properly via JsDoc custom tags
-   * https://github.com/open-wc/custom-elements-manifest/blob/8f9646c6a84dce20b1b018a61a8d024bae07d8cd/packages/analyzer/src/features/analyse-phase/class-jsdoc.js#L19
-   */
-  affixIconWithTrailingAttributes: Attribute[] = [
-    this.iconAttribute,
-    {
-      name: "icon-trailing",
-      fieldName: "iconTrailing",
-      description: 'Indicates the icon affix alignment.',
-      type: {
-        text: "boolean"
-      }
-    }
-  ]
-
-  extraAttributes: Record<string, Attribute[]> = {
-    AccordionItem: [
-      ...this.affixIconWithTrailingAttributes
-    ],
-    Button: [
-      ...this.affixIconWithTrailingAttributes
-    ],
-    Badge: [
-      ...this.affixIconWithTrailingAttributes
-    ],
-    Fab: [
-      ...this.affixIconWithTrailingAttributes
-    ],
-    Tab: [
-      ...this.affixIconWithTrailingAttributes
-    ],
-    Option: [
-      ...this.affixIconWithTrailingAttributes
-    ],
-    TextAnchor: [
-      ...this.affixIconWithTrailingAttributes
-    ],
-    Select: [
-      ...this.affixIconWithTrailingAttributes
-    ],
-
-    TextField: [
-      this.iconAttribute
-    ],
-    Combobox: [
-      this.iconAttribute
-    ],
-    Banner: [
-      this.iconAttribute
-    ],
-    NavItem: [
-      this.iconAttribute
-    ],
-    MenuItem: [
-      this.iconAttribute
-    ],
-    NavDisclosure: [
-      this.iconAttribute
-    ],
-    Note: [
-      this.iconAttribute
-    ]
-  }
-
   protected slots: Slot[] = []
 
   decorateSlots = (slots: Slot[]) => {
@@ -127,6 +51,5 @@ export class AttributesDecorator extends AbstractClassDeclarationDecorator imple
       ...(this.hasNonDefaultSlots ? [this.supportedSlotsAttribute] : []),
       this.styleAttribute,
       ...attributes,
-      ...(this.extraAttributes[this.className] ?? [])
     ]
 }


### PR DESCRIPTION
Some components inherit attributes not just from a superclass, but from a mixin. These are not exposed in custom-elements.json, so we have to search each component's `.d.ts` file, e.g. from https://unpkg.com/@vonage/vivid@latest/lib/select/select.d.ts we can see that it has the mixins `AffixIconWithTrailing, FormElement, FormElementHelperText, ErrorText, FormElementSuccessText`.

The hard-coded `VividMixins` config is copied verbatim from https://github.com/Vonage/vivid-vue/blob/4b80e55ffe667cde0f5ad8dc35e29292c6cca519/packages/generator/src/generator/customElementDeclarations.ts

This does at least mean we no longer need to hardcode which components have icon/icon-trailing attributes! 🎉 

As an example of the changes produced from this PR, VwcTextField now declares `success-text` and other attributes:
![image](https://github.com/Vonage/vivid-bindings-vue/assets/9611672/8d65f4a2-28c7-4c0c-9c02-195e8ec35d4f)
